### PR TITLE
Styling options

### DIFF
--- a/Source/StrongPass.js
+++ b/Source/StrongPass.js
@@ -171,8 +171,8 @@ provides: StrongPass
 		 */
 		createBox: function(){
 			//todo: should be templated
-			var width = this.element.getSize().x,
-				o = this.options;
+			var o = this.options,
+					width = o.containerWidth || this.element.getSize().x;
 
 			this.stbox = new Element(o.passStrengthZen, {
 				styles: {

--- a/Source/StrongPass.js
+++ b/Source/StrongPass.js
@@ -172,7 +172,7 @@ provides: StrongPass
 		createBox: function(){
 			//todo: should be templated
 			var o = this.options,
-					width = o.containerWidth || this.element.getSize().x;
+			    width = o.containerWidth || this.element.getSize().x;
 
 			this.stbox = new Element(o.passStrengthZen, {
 				styles: {


### PR DESCRIPTION
This change allows the user to specify the `pass-container` width through options.

Previously the width was calculated based on the visible width of the input element. This causes problem if the input is not visible at the moment when StrongPass is initialized.

For instance, if the input is inside a dialog, while it isn't fully rendered the input length is 0. If you initialize StrongPass before your dialog is rendered the `pass-container` length will be also 0.

The `containerWidth` option will force the width of the `pass-container`.
