### PR TITLE
allow bannedPasswords to be overwritten

### DIFF
--- a/Source/StrongPass.js
+++ b/Source/StrongPass.js
@@ -145,7 +145,7 @@ provides: StrongPass
 		 */
 		initialize: function(element, options){
 			this.setOptions(options);
-			if (Array.isArray(options.bannedPasswords)) {
+			if (options && Array.isArray(options.bannedPasswords)) {
 				this.bannedPasswords = options.bannedPasswords;
 			}
 			this.element = document.id(element);

--- a/Source/StrongPass.js
+++ b/Source/StrongPass.js
@@ -145,6 +145,9 @@ provides: StrongPass
 		 */
 		initialize: function(element, options){
 			this.setOptions(options);
+			if (Array.isArray(options.bannedPasswords)) {
+				this.bannedPasswords = options.bannedPasswords;
+			}
 			this.element = document.id(element);
 			this.options.render && this.createBox();
 			this.attachEvents();
@@ -297,6 +300,12 @@ provides: StrongPass
 			return score;
 		}
 	});
+
+	if (!Array.isArray) {
+		Array.isArray = function(arg) {
+			return Object.prototype.toString.call(arg) === '[object Array]';
+		};
+	}
 
 	if (typeof define === 'function' && define.amd) {
 		// return an AMD module


### PR DESCRIPTION
This change lets the developer to redefine the bannedPasswords array. In our specific case we want it to be empty.
